### PR TITLE
chore(spacedrive): added space drive

### DIFF
--- a/spacedrive/dot.yaml
+++ b/spacedrive/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: false
+
+linux|darwin:
+  installs: false


### PR DESCRIPTION
Spacedrive doesn't have any brew or scoop but adding an empty dot file will remind me to add them later on.