### PR TITLE
fix(nushell): fix string interpolation in ghaipr command

### DIFF
--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -39,7 +39,7 @@ def dotenv [
 
 def ghaipr [] {
   let $pr = (kit ai-pr-message | from json)
-  gh pr create --title=$pr.title --body=$pr.body --web
+  gh pr create $"--title=($pr.title)" $"--body=($pr.body)" --web
 }
 
 def gfu [


### PR DESCRIPTION
Fix string interpolation in ghaipr command

This PR fixes an issue with the `ghaipr` command in the Nushell initialization file. The previous implementation was incorrectly passing the title and body parameters to the GitHub CLI, which could lead to errors when creating pull requests with special characters or multiple words.

## Changes Overview

- Updated the string interpolation syntax in the `ghaipr` function
- Changed `--title=$pr.title` to `$"--title=($pr.title)"` to properly handle the string value
- Changed `--body=$pr.body` to `$"--body=($pr.body)"` to properly handle the string value
- This ensures that the title and body of the PR are correctly passed to the GitHub CLI command, preserving spaces and special characters

These changes maintain the same functionality while making the command more robust when handling various types of PR titles and descriptions.