### PR TITLE
feat(nushell): add aliases for GHF CLI tool

### DIFF
--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -411,4 +411,6 @@ alias stodo = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search
 alias stodom = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search -e --format pretty --jq "[.[] | select(.priority.value >= 5 and .priority.value < 8)]"
 alias stodoh = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search -e --format pretty --jq "[.[] | select(.priority.value >= 8)]"
 
+alias ghf = deno run -A jsr:@michaelmass/ghf/cli apply
+
 clear

--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -412,5 +412,6 @@ alias stodom = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search 
 alias stodoh = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search -e --format pretty --jq "[.[] | select(.priority.value >= 8)]"
 
 alias ghf = deno run -A jsr:@michaelmass/ghf/cli
+alias ghfa = deno run -A jsr:@michaelmass/ghf/cli apply
 
 clear

--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -411,6 +411,6 @@ alias stodo = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search
 alias stodom = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search -e --format pretty --jq "[.[] | select(.priority.value >= 5 and .priority.value < 8)]"
 alias stodoh = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search -e --format pretty --jq "[.[] | select(.priority.value >= 8)]"
 
-alias ghf = deno run -A jsr:@michaelmass/ghf/cli apply
+alias ghf = deno run -A jsr:@michaelmass/ghf/cli
 
 clear


### PR DESCRIPTION
Added aliases for the GHF CLI tool

This PR adds two new aliases to the nushell configuration:

1. `ghf` - Alias for running the GHF CLI tool (`deno run -A jsr:@michaelmass/ghf/cli`)
2. `ghfa` - Alias for applying GHF commands (`deno run -A jsr:@michaelmass/ghf/cli apply`)

## Overview

These aliases will make it more convenient to interact with the GHF CLI tool by:

- Shortening the command needed to run the tool
- Providing a dedicated shorthand for the common "apply" operation
- Maintaining consistency with other Deno-based tool aliases already in the configuration

This change follows the pattern established for other CLI tools in the dotfiles, like the existing stodo aliases.