### PR TITLE
fix(nushell): update dotenv function to use `where` instead of `filter` because filter is deprecated

### DIFF
--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -32,7 +32,7 @@ def dotenv [
   file = ".env"
 ] {
   let $file = ([$file ".env"] | where ($it | path exists) | first)
-  let $lines = (open --raw $file | lines | str trim | compact --empty | filter {|it| ($it | str starts-with "#" | not $in)})
+  let $lines = (open --raw $file | lines | str trim | compact --empty | where {|it| ($it | str starts-with "#" | not $in)})
   let $record = ($lines | split column "=" | reduce -f {} {|it, acc| $acc | upsert $it.column1 $it.column2 })
   return $record
 }


### PR DESCRIPTION
Fix: Update Nushell dotenv Function to Use `where` Instead of `filter`
