### PR TITLE
feat(finicky): add new work URLs for Zoom and Sauron instances

### DIFF
--- a/finicky/finicky.js
+++ b/finicky/finicky.js
@@ -28,6 +28,9 @@ const workUrls = [
   "botpress.bamboohr.com",
   "meet.google.com",
   "linear.app/botpress",
+  "google.zoom.us",
+  "sauron.botpress.cloud",
+  "sauron.botpress.dev",
 ];
 
 const workUrl = ({ url }) => {


### PR DESCRIPTION
Add New Work URLs to Finicky Configuration

This PR adds three new work URL patterns to the `finicky.js` configuration file:
- google.zoom.us
- sauron.botpress.cloud
- sauron.botpress.dev
