### PR TITLE
feat(nushell): add aliases for Yaak application

### DIFF
--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -414,4 +414,7 @@ alias stodoh = deno run --allow-run=rg,git,jq jsr:@michaelmass/stodo/cli search 
 alias ghf = deno run -A jsr:@michaelmass/ghf/cli
 alias ghfa = deno run -A jsr:@michaelmass/ghf/cli apply
 
+alias yaak = ^open -a "/Applications/Yaak.app"
+alias yak = yaak
+
 clear


### PR DESCRIPTION
Added aliases for Yaak Application

This change adds two new aliases to the nushell init file for opening the Yaak application on macOS:
- `yaak` - Opens the Yaak application using the system `open` command
- `yak` - Added as a convenience shorthand for the same command
