### PR TITLE
feat(yaak): add installation instructions in dot.yaml for multiple platforms

### DIFF
--- a/yaak/dot.yaml
+++ b/yaak/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: scoop install yaak
+
+linux|darwin:
+  installs: brew install --cask yaak


### PR DESCRIPTION
**Added installation instructions for Yaak in dot.yaml**

This PR adds a new dot.yaml configuration file for Yaak with installation instructions for different operating systems:

- For Windows: Added `scoop install yaak` command
- For Linux and macOS (darwin): Added `brew install --cask yaak` command
