### PR TITLE
fix(nushell): check if repository directory exists before cloning

### DIFF
--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -132,7 +132,12 @@ def ghrepoclone [
   let repoWithOwner = ([$org, $repo] | path join)
   let target = ([$folder, $repoWithOwner] | where ($it != "") | first)
   let directory = ([$nu.home-path "Documents/dev" $target] | path join)
-  gh repo clone $"($org)/($repo)" $directory
+
+  if ($directory | path exists) {
+    print $"Directory ($directory) already exists"
+  } else {
+    gh repo clone $"($org)/($repo)" $directory
+  }
 
   if ($open) {
     code $directory


### PR DESCRIPTION
Fix to check if repository directory exists before cloning

This PR adds a check in the `ghrepoclone` function to see if the target directory already exists before attempting to clone a GitHub repository. 
