### PR TITLE
feat(dotfiles): add Krisp install config and enable workbench.browser.showInTitleBar

### DIFF
--- a/code/settings.json
+++ b/code/settings.json
@@ -284,7 +284,8 @@
   },
   "extensions.ignoreRecommendations": true,
   "editor.wordWrap": "on",
-  "workbench.secondarySideBar.defaultVisibility": "hidden"
+  "workbench.secondarySideBar.defaultVisibility": "hidden",
+  "workbench.browser.showInTitleBar": false
   // "workbench.statusBar.visible": false,
   // "workbench.editor.showTabs": "none",
   // "breadcrumbs.filePath": "off",

--- a/krisp/dot.yaml
+++ b/krisp/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: false
+
+linux|darwin:
+  installs: brew install --cask krisp


### PR DESCRIPTION
Add Krisp installation config and enable workbench.browser.showInTitleBar in VS Code settings