### PR TITLE
feat(aws2-wrap): add dot.yaml with platform‑specific install instructions

### DIFF
--- a/aws2-wrap/dot.yaml
+++ b/aws2-wrap/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: false
+
+linux|darwin:
+  installs: brew install aws2-wrap


### PR DESCRIPTION
Add aws2‑wrap dot.yaml with platform‑specific install instructions.