### PR TITLE
feat(notion-mail): add dot.yaml with platform-specific install instructions and disable Windows installs

### DIFF
--- a/notion-mail/dot.yaml
+++ b/notion-mail/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: false
+
+linux|darwin:
+  installs: brew install --cask notion-mail


### PR DESCRIPTION
Add notion-mail dot.yaml with platform‑specific install instructions and disable Windows installs