### PR TITLE
chore(codex): switch installation to brew on Linux/macOS

### DIFF
--- a/codex/dot.yaml
+++ b/codex/dot.yaml
@@ -2,4 +2,4 @@ windows:
   installs: false
 
 linux|darwin:
-  installs: pnpm i -g @openai/codex
+  installs: brew install codex


### PR DESCRIPTION
Switch codex installation to brew on Linux/macOS