### PR TITLE
feat(dotfiles): add installation scripts for infisical, obs, and wrangler

### DIFF
--- a/infisical/dot.yaml
+++ b/infisical/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: false
+
+linux|darwin:
+  installs: brew install infisical/get-cli/infisical

--- a/obs/dot.yaml
+++ b/obs/dot.yaml
@@ -1,0 +1,5 @@
+windows:
+  installs: scoop install obs-studio
+
+linux|darwin:
+  installs: brew list obs &>/dev/null || brew install --cask obs

--- a/wrangler/dot.yaml
+++ b/wrangler/dot.yaml
@@ -1,0 +1,11 @@
+windows:
+  installs:
+    cmd: pnpm i -g wrangler@latest
+    depends:
+      - pnpm
+
+linux|darwin:
+  installs:
+    cmd: pnpm i -g wrangler@latest
+    depends:
+      - pnpm


### PR DESCRIPTION
Add installation scripts for infisical, obs, and wrangler.

This PR introduces new dot.yaml files for three tools:

- **infisical**: Provides install instructions for Windows (none) and Linux/macOS via Homebrew.
- **obs**: Adds Windows install using Scoop and Linux/macOS install via Homebrew with a check to avoid duplicate installations.
- **wrangler**: Supplies a cross‑platform install configuration that runs `pnpm i -g wrangler@latest` after ensuring `pnpm` is available on both Windows and Linux/macOS.

These additions expand the repository’s setup capabilities, allowing automated installation of these utilities across supported platforms.