### PR TITLE
refactor(nushell): remove redundant gaa calls in lhf and lhc functions

### DIFF
--- a/nushell/init.nu
+++ b/nushell/init.nu
@@ -501,7 +501,6 @@ def gfumerge [
 def lhf [] {
   gaa
   lefthook run format
-  gaa
 }
 
 def symlink [
@@ -514,7 +513,6 @@ def symlink [
 def lhc [] {
   gaa
   lefthook run pre-commit
-  gaa
 }
 
 def new [


### PR DESCRIPTION
Remove redundant `gaa` calls in lhf and lhc functions