### PR TITLE
chore(alacritty): disable quarantine removal on macOS

### DIFF
--- a/alacritty/dot.yaml
+++ b/alacritty/dot.yaml
@@ -9,6 +9,6 @@ windows:
 linux|darwin:
   installs: |
     brew install alacritty
-    xattr -dr com.apple.quarantine "/Applications/Alacritty.app"
+    # xattr -dr com.apple.quarantine "/Applications/Alacritty.app"
   links:
     unix-alacritty-{{ whoami.arch }}.toml: ~/.alacritty.toml


### PR DESCRIPTION
Disable quarantine removal for Alacritty on macOS.

**Overview**
- Updated `alacritty/dot.yaml` to comment out the `xattr -dr com.apple.quarantine "/Applications/Alacritty.app"` command.
- This prevents the automatic removal of the quarantine attribute during installation, which may be undesirable in certain environments.
- No other changes were made; the installation script remains unchanged for Linux and macOS platforms.
- The modification ensures the setup process is safer and respects user preferences regarding quarantine handling.