### PR TITLE
feat(cachebro): add cachebro init to install scripts for Windows, Linux, and macOS

### DIFF
--- a/cachebro/dot.yaml
+++ b/cachebro/dot.yaml
@@ -1,11 +1,15 @@
 windows:
   installs:
-    cmd: pnpm i -g cachebro@latest
+    cmd: |
+      pnpm i -g cachebro@latest
+      cachebro init
     depends:
       - pnpm
 
 linux|darwin:
   installs:
-    cmd: pnpm i -g cachebro@latest
+    cmd: |
+      pnpm i -g cachebro@latest
+      cachebro init
     depends:
       - pnpm


### PR DESCRIPTION
Add cachebro init to install scripts for Windows, Linux, and macOS