### PR TITLE
feat(install): make Homebrew installation non-interactive


### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 eval "$(/opt/homebrew/bin/brew shellenv)"
 yes | brew install volllly/tap/rotz
 


### PR DESCRIPTION
Make Homebrew installation non-interactive and add ROTZ tap installation